### PR TITLE
Add translation column

### DIFF
--- a/background.js
+++ b/background.js
@@ -42,30 +42,33 @@ function saveSelectedText() {
         
         if (response && response.text) {
           try {
-            // 获取当前保存的单词列表
-            chrome.storage.local.get(['wordList'], (result) => {
-              const wordList = result.wordList || [];
-              
-              // 添加新单词
-              wordList.push({
-                word: response.text,
-                context: "", // 可以扩展获取上下文
-                url: response.url,
-                title: response.title,
-                date: new Date().toLocaleDateString(),
-                timestamp: new Date().getTime() // 添加毫秒级时间戳
-              });
-              
-              // 保存更新后的列表
-              chrome.storage.local.set({wordList: wordList}, () => {
-                // 显示成功提示
-                chrome.action.setBadgeText({text: "✓"});
-                setTimeout(() => chrome.action.setBadgeText({text: ""}), 2000);
-                
-                // 发送消息给popup更新单词计数
-                chrome.runtime.sendMessage({
-                  action: "wordAdded", 
-                  count: wordList.length
+            translateWord(response.text).then((translation) => {
+              // 获取当前保存的单词列表
+              chrome.storage.local.get(['wordList'], (result) => {
+                const wordList = result.wordList || [];
+
+                // 添加新单词
+                wordList.push({
+                  word: response.text,
+                  translation: translation,
+                  context: "", // 可以扩展获取上下文
+                  url: response.url,
+                  title: response.title,
+                  date: new Date().toLocaleDateString(),
+                  timestamp: new Date().getTime() // 添加毫秒级时间戳
+                });
+
+                // 保存更新后的列表
+                chrome.storage.local.set({wordList: wordList}, () => {
+                  // 显示成功提示
+                  chrome.action.setBadgeText({text: "✓"});
+                  setTimeout(() => chrome.action.setBadgeText({text: ""}), 2000);
+
+                  // 发送消息给popup更新单词计数
+                  chrome.runtime.sendMessage({
+                    action: "wordAdded",
+                    count: wordList.length
+                  });
                 });
               });
             });
@@ -78,8 +81,25 @@ function saveSelectedText() {
       });
     }).catch(err => {
       console.error("无法在当前页面执行脚本:", err);
-      chrome.action.setBadgeText({text: "×"});
-      setTimeout(() => chrome.action.setBadgeText({text: ""}), 2000);
-    });
+  chrome.action.setBadgeText({text: "×"});
+  setTimeout(() => chrome.action.setBadgeText({text: ""}), 2000);
   });
-} 
+  });
+}
+
+// 使用公共翻译接口获取单词翻译
+function translateWord(word) {
+  const url = `https://api.mymemory.translated.net/get?q=${encodeURIComponent(word)}&langpair=en|zh-CN`;
+  return fetch(url)
+    .then(response => response.json())
+    .then(data => {
+      if (data && data.responseData && data.responseData.translatedText) {
+        return data.responseData.translatedText;
+      }
+      return '';
+    })
+    .catch(err => {
+      console.error('Translation error:', err);
+      return '';
+    });
+}

--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,9 @@
   "version": "1.0",
   "description": "选中单词保存到本地便于后续复习",
   "permissions": ["storage", "activeTab", "scripting", "contextMenus", "downloads"],
+  "host_permissions": [
+    "https://api.mymemory.translated.net/*"
+  ],
   "action": {
     "default_popup": "popup.html",
     "default_icon": {

--- a/options.html
+++ b/options.html
@@ -97,10 +97,11 @@
         padding: 15px;
       }
       
-      th:nth-child(1), td:nth-child(1) { width: 30%; }
-      th:nth-child(2), td:nth-child(2) { width: 45%; }
-      th:nth-child(3), td:nth-child(3) { width: 25%; }
-    }
+        th:nth-child(1), td:nth-child(1) { width: 25%; }
+        th:nth-child(2), td:nth-child(2) { width: 25%; }
+        th:nth-child(3), td:nth-child(3) { width: 30%; }
+        th:nth-child(4), td:nth-child(4) { width: 20%; }
+      }
   </style>
 </head>
 <body>
@@ -121,6 +122,7 @@
         <thead>
           <tr>
             <th>单词</th>
+            <th>翻译</th>
             <th>来源页面</th>
             <th>日期</th>
           </tr>

--- a/options.js
+++ b/options.js
@@ -44,11 +44,15 @@ function loadWordList() {
     // 填充表格
     wordList.forEach(item => {
       const row = document.createElement('tr');
-      
+
       const wordCell = document.createElement('td');
       wordCell.textContent = item.word;
       row.appendChild(wordCell);
-      
+
+      const translationCell = document.createElement('td');
+      translationCell.textContent = item.translation || '';
+      row.appendChild(translationCell);
+
       const sourceCell = document.createElement('td');
       const sourceLink = document.createElement('a');
       sourceLink.href = item.url;
@@ -56,11 +60,11 @@ function loadWordList() {
       sourceLink.target = '_blank';
       sourceCell.appendChild(sourceLink);
       row.appendChild(sourceCell);
-      
+
       const dateCell = document.createElement('td');
       dateCell.textContent = item.date;
       row.appendChild(dateCell);
-      
+
       wordTableBody.appendChild(row);
     });
   });
@@ -87,7 +91,7 @@ function exportToCSV() {
     });
     
     // 创建CSV内容
-    let csvContent = 'Word,Context,Title,URL,Date\n';
+    let csvContent = 'Word,Translation,Context,Title,URL,Date\n';
     
     wordList.forEach(item => {
       // 处理CSV中的特殊字符
@@ -103,6 +107,7 @@ function exportToCSV() {
       
       csvContent += [
         processValue(item.word),
+        processValue(item.translation),
         processValue(item.context),
         processValue(item.title),
         processValue(item.url),


### PR DESCRIPTION
## Summary
- include external translation API permissions
- store translations when saving selected text
- display translations in the options page table
- export CSV with translation column
- adjust responsive table layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d4f30e538832ebd5f2389941091ec